### PR TITLE
Fix how we determine the api_fqdn on azure

### DIFF
--- a/files/chef-marketplace-cookbooks/chef-marketplace/libraries/helpers.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/libraries/helpers.rb
@@ -202,7 +202,7 @@ module Marketplace
           when 'gce'
             node['cloud_v2']['public_ipv4']
           when 'azure'
-            "#{node['cloud_v2']['public_hostname']}.cloudapp.net"
+            node['cloud_v2']['public_hostname'] ? "#{node['cloud_v2']['public_hostname']}.cloudapp.net" : node['fqdn']
           else # aws, etc..
             node['cloud_v2']['public_hostname'] || node['cloud_v2']['local_hostname'] || node['fqdn']
           end


### PR DESCRIPTION
The only way the cloud_v2 api determines the public hostname is if a hints file with the information is passed in via knife-azure. Little to no users will be using this method when deploying from the marketplace.

We should default to the fqdn to avoid things like `"api_fqdn": ".cloudapp.net"` from happening if the user sets the hostname using `chef-marketplace-ctl hostname`.

https://github.com/chef/ohai/blob/master/lib/ohai/plugins/azure.rb#L20-L34