### PR TITLE
Fix omnibus-ctl naming collision

### DIFF
--- a/files/chef-marketplace-ctl-commands/register_node.rb
+++ b/files/chef-marketplace-ctl-commands/register_node.rb
@@ -1,7 +1,15 @@
 require 'highline/import'
 
 add_command_under_category 'register-node', 'Configuration', 'Register node with Chef to enable support', 2 do
-  config = default_config
+  config = {
+    'chef-marketplace' => {
+      'registration' => {
+        'address' => 'marketplace.chef.io'
+      }
+    },
+    'run_list' => ['chef-marketplace::register_node']
+  }
+
   ui = HighLine.new
 
   if File.exist?('/etc/chef-marketplace/chef-marketplace-running.json')
@@ -56,15 +64,4 @@ add_command_under_category 'register-node', 'Configuration', 'Register node with
   File.write(register_json_file, JSON.pretty_generate(config))
   status = run_chef(register_json_file, '--lockfile /tmp/chef-client-register-node.lock')
   status.success? ? exit(0) : exit(1)
-end
-
-def default_config
-  {
-    'chef-marketplace' => {
-      'registration' => {
-        'address' => 'marketplace.chef.io'
-      }
-    },
-    'run_list' => ['chef-marketplace::register_node']
-  }
 end

--- a/files/chef-marketplace-ctl-commands/upgrade.rb
+++ b/files/chef-marketplace-ctl-commands/upgrade.rb
@@ -1,10 +1,17 @@
 require 'json'
 
 add_command_under_category 'upgrade', 'Configuration', 'Upgrade or install Chef software', 2 do
-  config = default_config
+  config = {
+    'chef-marketplace' => {
+      'role' => 'aio',
+      'upgrade_packages' => []
+    },
+    'run_list' => ['chef-marketplace::upgrade']
+  }
 
   if File.exist?('/etc/chef-marketplace/chef-marketplace-running.json')
-    config['chef-marketplace']['role'] = JSON.parse(IO.read('/etc/chef-marketplace/chef-marketplace-running.json'))['chef-marketplace']['role']
+    running_config = JSON.parse(IO.read('/etc/chef-marketplace/chef-marketplace-running.json'))
+    config['chef-marketplace']['role'] = running_config['chef-marketplace']['role']
   end
 
   OptionParser.new do |opts|
@@ -58,14 +65,4 @@ add_command_under_category 'upgrade', 'Configuration', 'Upgrade or install Chef 
   File.write(upgrade_json_file, JSON.pretty_generate(config))
   status = run_chef(upgrade_json_file, '--lockfile /tmp/chef-client-upgrade.lock')
   status.success? ? exit(0) : exit(1)
-end
-
-def default_config
-  {
-    'chef-marketplace' => {
-      'role' => 'aio',
-      'upgrade_packages' => []
-    },
-    'run_list' => ['chef-marketplace::upgrade']
-  }
 end


### PR DESCRIPTION
OmnibusCtl was class_eval-ing the `default_config` in both commands
because it was not in the command block.  I removed both methods and
went with a simple declarative hash.