### PR TITLE
add sudoers.d/chef-compliance for marketplace registration

### DIFF
--- a/files/chef-marketplace-cookbooks/chef-marketplace/files/default/chef-compliance-sudoers
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/files/default/chef-compliance-sudoers
@@ -1,0 +1,3 @@
+Cmnd_Alias REGISTER = /usr/bin/chef-marketplace-ctl register-node *
+chef-compliance ALL=(root) NOPASSWD: REGISTER
+Defaults!REGISTER !requiretty

--- a/files/chef-marketplace-cookbooks/chef-marketplace/libraries/helpers.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/libraries/helpers.rb
@@ -34,6 +34,14 @@ class Marketplace
       Dir['/etc/sudoers.d/*']
     end
 
+    def our_sudoers
+      %w(chef-compliance)
+    end
+
+    def unexpected_sudoers
+      current_sudoers - our_sudoers
+    end
+
     def gecos
       case node['chef-marketplace']['platform']
       when 'aws' then 'Ec2 User'

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_compliance_enable.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_compliance_enable.rb
@@ -10,3 +10,11 @@ template '/etc/chef-compliance/chef-compliance.rb' do
   group 'root'
   action :create
 end
+
+file '/etc/sudoers.d/chef-compliance' do
+  source 'chef-compliance-sudoers'
+  owner 'root'
+  group 'root'
+  mode 0440
+  action :create
+end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_security.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_security.rb
@@ -39,7 +39,7 @@ system_ssh_keys.each do |key|
   end
 end
 
-current_sudoers.each do |sudo_user|
+unexpected_sudoers.each do |sudo_user|
   file sudo_user do
     action :delete
   end


### PR DESCRIPTION
In this current form, it will allow the chef-compliance user (under which the API runs) to run `sudo /usr/bin/chef-marketplace-ctl register-node` _with any arguments_, without a password.

Btw, looking at [chef-marketplace::_security](https://github.com/chef-partners/omnibus-marketplace/blob/master/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_security.rb#L42-L46), it struck me as curious to delete anything in `/etc/sudoers.d/*`, but not control `/etc/sudoers`, which might just use another includedir, or contain many sudoer definitions itself.