### PR TITLE
Allow running chef-marketplace-ctl register-node as a non-root user

### DIFF
--- a/config/software/chef-marketplace-cookbooks.rb
+++ b/config/software/chef-marketplace-cookbooks.rb
@@ -23,4 +23,7 @@ build do
 
   erb source: 'solo.rb.erb',
       dest: "#{install_dir}/embedded/cookbooks/solo.rb"
+
+  erb source: 'non_root_solo.rb.erb',
+      dest: "#{install_dir}/embedded/cookbooks/non_root_solo.rb"
 end

--- a/config/templates/chef-marketplace-cookbooks/non_root_solo.rb.erb
+++ b/config/templates/chef-marketplace-cookbooks/non_root_solo.rb.erb
@@ -1,0 +1,8 @@
+cookbook_path '/opt/chef-marketplace/embedded/cookbooks'
+cache_path '/tmp/chef-marketplace/local-mode-cache'
+node_path '/tmp/chef-marketplace/local-mode-cache/nodes'
+file_cache_path '/tmp/chef-marketplace/local-mode-cache/file_cache'
+verbose_logging true
+ssl_verify_mode :verify_peer
+client_fork false
+listen false

--- a/config/templates/chef-marketplace-cookbooks/solo.rb.erb
+++ b/config/templates/chef-marketplace-cookbooks/solo.rb.erb
@@ -1,6 +1,6 @@
 cookbook_path   "/opt/chef-marketplace/embedded/cookbooks"
-cache_path "/var/opt/opscode/local-mode-cache"
-file_cache_path "/opt/chef-marketplace/embedded/cookbooks/cache"
+cache_path "/var/opt/chef-marketplace/local-mode-cache"
+file_cache_path "/var/opt/chef-marketplace/embedded/cookbooks/cache"
 verbose_logging true
 ssl_verify_mode :verify_peer
 client_fork false

--- a/files/chef-marketplace-cookbooks/chef-marketplace/libraries/helpers.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/libraries/helpers.rb
@@ -138,7 +138,7 @@ class Marketplace
       }
 
       vars.merge!(
-        compliance_url: role == 'compliance' ? manage_url : false,
+        compliance_url: role == 'compliance' ? "#{manage_url}/#/setup" : false,
         manage_url: role =~ /aio|server/ ? manage_url : false,
         analytics_url: role =~ /aio|analytics/ ? analytics_href : false
       ) unless security_enabled?

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/config.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/config.rb
@@ -5,6 +5,13 @@ directory '/etc/chef-marketplace' do
   action :create
 end
 
+file '/etc/chef-marketplace/marketplace.rb' do
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :create_if_missing
+end
+
 if File.exist?('/etc/chef-marketplace/marketplace.rb')
   Marketplace.from_file('/etc/chef-marketplace/marketplace.rb')
 end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/default.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/default.rb
@@ -4,5 +4,5 @@ file '/etc/chef-marketplace/chef-marketplace-running.json' do
   content lazy { Chef::JSONCompat.to_json_pretty('chef-marketplace' => node['chef-marketplace']) }
   owner 'root'
   group 'root'
-  mode '0600'
+  mode '0644'
 end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/register_node.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/register_node.rb
@@ -1,4 +1,10 @@
-include_recipe 'chef-marketplace::config'
+if File.exist?('/etc/chef-marketplace/marketplace.rb')
+  Marketplace.from_file('/etc/chef-marketplace/marketplace.rb')
+end
+
+node.consume_attributes('chef-marketplace' => Marketplace.save(false))
+
+determine_api_fqdn
 
 if outbound_traffic_disabled?
   Chef::Log.warn 'Skipping node registration because outbound traffic is disabled'


### PR DESCRIPTION
Run the embedded chef-client run with a globally accessible cache
so that unprivileged users can run the command.  This will allow
the chef-compliance core application to run the command for us
during the setup wizard.  It should also allow the opscode user
to do the same if we implement registration in chef-manage.