### PR TITLE
Ryan/chores

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,3 @@ DEPENDENCIES
   rubocop
   sequel
   test-kitchen (~> 1.3)
-
-BUNDLED WITH
-   1.11.2

--- a/files/chef-marketplace-cookbooks/chef-marketplace/Berksfile
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/Berksfile
@@ -2,6 +2,5 @@ source "https://supermarket.chef.io"
 
 cookbook "hostname", github: "3ofcoins/chef-cookbook-hostname", branch: "v0.4.0"
 cookbook "enterprise", git: "https://github.com/opscode-cookbooks/enterprise-chef-common.git"
-cookbook "chef-ingredient"
 
 metadata

--- a/files/chef-marketplace-cookbooks/chef-marketplace/Berksfile.lock
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/Berksfile.lock
@@ -1,34 +1,36 @@
 DEPENDENCIES
-  chef-ingredient
   chef-marketplace
     path: .
     metadata: true
+  enterprise
+    git: https://github.com/opscode-cookbooks/enterprise-chef-common.git
+    revision: bb86beb1a8f9c6cac609b057c3411c75a1428786
   hostname
     git: git://github.com/3ofcoins/chef-cookbook-hostname.git
     revision: 565b26905509da7494e502476a99d0b82c5f4604
     branch: v0.4.0
 
 GRAPH
-  apt (2.9.2)
-  apt-chef (0.2.2)
-    apt (>= 0.0.0)
-  chef-ingredient (0.16.0)
-    apt-chef (>= 0.2.0)
-    yum-chef (>= 0.2.0)
+  apt (3.0.0)
+  chef-ingredient (0.18.2)
   chef-marketplace (0.0.1)
     apt (>= 0.0.0)
     chef-ingredient (>= 0.0.0)
+    enterprise (>= 0.0.0)
     hostname (>= 0.0.0)
     motd (>= 0.0.0)
     yum-centos (>= 0.0.0)
-  chef_handler (1.2.0)
+  chef_handler (1.3.0)
+  enterprise (0.10.0)
+    runit (> 1.0.0)
   hostname (0.4.0)
     hostsfile (>= 0.0.0)
   hostsfile (2.4.5)
-  motd (0.6.3)
+  motd (0.6.4)
     chef_handler (>= 0.0.0)
-  yum (3.8.2)
-  yum-centos (0.4.11)
-    yum (~> 3.2)
-  yum-chef (0.2.2)
-    yum (>= 3.2)
+  packagecloud (0.2.0)
+  runit (1.7.6)
+    packagecloud (>= 0.0.0)
+  yum (3.10.0)
+  yum-centos (0.4.12)
+    yum (~> 3.10.0)

--- a/files/chef-marketplace-cookbooks/chef-marketplace/libraries/helpers.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/libraries/helpers.rb
@@ -135,22 +135,22 @@ class Marketplace
       vars = {
         doc_url: node["chef-marketplace"]["documentation"]["url"],
         support_email: node["chef-marketplace"]["support"]["email"],
-        role: node["chef-marketplace"]["role"]
+        role: node["chef-marketplace"]["role"],
+        analytics_url: manage_url,
+        manage_url: manage_url,
+        compliance_url: manage_url
       }
 
       case node["chef-marketplace"]["role"]
       when "server", "aio"
         vars[:role_name] = 'Chef Server'
-        unless security_enabled?
-          vars[:analytics_url] = analytics_url
-          vars[:manage_url] = manage_url
-        end
+        vars[:setup_wizard] = "#{manage_url}/signup"
       when "analytics"
         vars[:role_name] = "Chef Analytics"
-        vars[:analytics_url] = manage_url unless security_enabled?
+        vars[:setup_wizard] = "chef-marketplace-ctl setup"
       when "compliance"
         vars[:role_name] = "Chef Compliance"
-        vars[:compliance_url] = "#{manage_url}/#/setup" unless security_enabled?
+        vars[:setup_wizard] = "#{manage_url}/#/setup"
       end
 
       vars

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_analytics_enable.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_analytics_enable.rb
@@ -17,3 +17,14 @@ template "/etc/cron.d/actions-trimmer" do
   )
   action actions_trimmer_action
 end
+
+license_file = "/var/opt/opscode-analytics/.license.accepted"
+
+directory ::File.dirname(license_file) do
+  action :create
+end
+
+file license_file do
+  action :touch
+  not_if { ::File.exist?(license_file) }
+end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_biscotti_enable.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_biscotti_enable.rb
@@ -20,6 +20,7 @@ directory ::File.dirname(server_lb_template) do
   owner "root"
   group "root"
   mode "0644"
+  recursive true
   action :create
   only_if { node["chef-marketplace"]["role"] =~ /aio|server/ }
 end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_compliance_enable.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_compliance_enable.rb
@@ -10,3 +10,14 @@ template "/etc/chef-compliance/chef-compliance.rb" do
   group "root"
   action :create_if_missing
 end
+
+license_file = "/var/opt/chef-compliance/.license.accepted"
+
+directory ::File.dirname(license_file) do
+  action :create
+end
+
+file license_file do
+  action :touch
+  not_if { ::File.exist?(license_file) }
+end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_server_enable.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_server_enable.rb
@@ -52,3 +52,16 @@ template "/etc/chef-manage/manage.rb" do
   group "opscode"
   action :create_if_missing
 end
+
+["opscode", "chef-manage", "opscode-reporting"].map do |package|
+  "/var/opt/#{package}/.license.accepted"
+end.each do |license_file|
+  directory ::File.dirname(license_file) do
+    action :create
+  end
+
+  file license_file do
+    action :touch
+    not_if { ::File.exist?(license_file) }
+  end
+end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_upgrade_analytics.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_upgrade_analytics.rb
@@ -1,9 +1,31 @@
-chef_ingredient "analytics" do
-  action :upgrade
-  notifies :run, "bash[opscode-analytics-ctl reconfigure]", :immediately if analytics_configured?
-end
-
 bash "opscode-analytics-ctl reconfigure" do
   code "opscode-analytics-ctl reconfigure"
+  only_if { analytics_configured? }
   action :nothing
+end
+
+ruby_block "remove-analytics-from-cache" do
+  block do
+    package = Dir["#{Chef::Config[:file_cache_path]}/*"].find { |f| f =~ /opscode-analytics/ }
+    FileUtils.rm(package) if package && File.exist?(package)
+  end
+  action :nothing
+end
+
+bash "opscode-analytics-ctl stop" do
+  code "opscode-analytics-ctl stop"
+  only_if { analytics_configured? }
+end
+
+chef_ingredient "analytics" do
+  action :upgrade
+  notifies :run, "bash[opscode-analytics-ctl reconfigure]", :immediately
+  notifies :run, "ruby_block[remove-analytics-from-cache]", :immediately
+  notifies :run, "bash[yum-clean-all]", :immediately
+  notifies :run, "bash[apt-get-clean]", :immediately
+end
+
+bash "opscode-analytics-ctl stop" do
+  code "opscode-analytics-ctl stop"
+  only_if { analytics_configured? }
 end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_upgrade_chef_marketplace.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_upgrade_chef_marketplace.rb
@@ -1,9 +1,29 @@
-chef_ingredient "chef-marketplace" do
-  action :upgrade
-  notifies :run, "bash[chef-marketplace-ctl reconfigure]"
-end
-
 bash "chef-marketplace-ctl reconfigure" do
   code "chef-marketplace-ctl reconfigure"
   action :nothing
+end
+
+ruby_block "remove-marketplace-from-cache" do
+  block do
+    package = Dir["#{Chef::Config[:file_cache_path]}/*"].find { |f| f =~ /chef-marketplace/ }
+    FileUtils.rm(package) if package && File.exist?(package)
+  end
+
+  action :nothing
+end
+
+bash "chef-marketplace-ctl stop" do
+  code "chef-marketplace-ctl stop"
+end
+
+chef_ingredient "chef-marketplace" do
+  action :upgrade
+  notifies :run, "bash[chef-marketplace-ctl reconfigure]"
+  notifies :run, "ruby_block[remove-marketplace-from-cache]", :immediately
+  notifies :run, "bash[yum-clean-all]", :immediately
+  notifies :run, "bash[apt-get-clean]", :immediately
+end
+
+bash "chef-marketplace-ctl start" do
+  code "chef-marketplace-ctl start"
 end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_upgrade_chef_server.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_upgrade_chef_server.rb
@@ -1,65 +1,113 @@
+# Possibly run actions
 bash "chef-server-ctl reconfigure" do
   code "chef-server-ctl reconfigure"
+  only_if { chef_server_configured? }
   action :nothing
 end
 
 bash "chef-server-ctl upgrade" do
   code "chef-server-ctl upgrade"
-  action :nothing
-end
-
-bash "chef-server-ctl restart" do
-  code "chef-server-ctl restart"
+  only_if { chef_server_configured? }
   action :nothing
 end
 
 bash "chef-server-ctl start" do
   code "chef-server-ctl start"
+  only_if { chef_server_configured? }
   action :nothing
 end
 
 bash "opscode-reporting-ctl reconfigure" do
   code "opscode-reporting-ctl reconfigure"
+  only_if { chef_server_configured? }
   action :nothing
 end
 
 bash "chef-manage-ctl reconfigure" do
   code "chef-manage-ctl reconfigure"
+  only_if { chef_server_configured? }
   action :nothing
 end
 
-bash "chef-manage-ctl restart" do
-  code "chef-manage-ctl restart"
+ruby_block "remove-chef-server-from-cache" do
+  block do
+    package = Dir["#{Chef::Config[:file_cache_path]}/*"].find { |f| f =~ /chef-server-core/ }
+    FileUtils.rm(package) if package && File.exist?(package)
+  end
+
   action :nothing
+end
+
+ruby_block "remove-reporting-from-cache" do
+  block do
+    package = Dir["#{Chef::Config[:file_cache_path]}/*"].find { |f| f =~ /opscode-reporting/ }
+    FileUtils.rm(package) if package && File.exist?(package)
+  end
+
+  action :nothing
+end
+
+ruby_block "remove-manage-from-cache" do
+  block do
+    package = Dir["#{Chef::Config[:file_cache_path]}/*"].find { |f| f =~ /chef-manage/ }
+    FileUtils.rm(package) if package && File.exist?(package)
+  end
+
+  action :nothing
+end
+
+# Chef Server
+bash "chef-server-ctl stop" do
+  code "chef-server-ctl stop"
+  only_if { chef_server_configured? }
 end
 
 chef_ingredient "chef-server" do
   action :upgrade
 
-  if chef_server_configured?
-    notifies :run, "bash[chef-server-ctl reconfigure]", :immediately
-    notifies :run, "bash[chef-server-ctl upgrade]", :immediately
-    notifies :run, "bash[chef-server-ctl restart]", :immediately
-  end
+  notifies :run, "bash[chef-server-ctl reconfigure]", :immediately
+  notifies :run, "bash[chef-server-ctl upgrade]", :immediately
+  notifies :run, "ruby_block[remove-chef-server-from-cache]", :immediately
+  notifies :run, "bash[yum-clean-all]", :immediately
+  notifies :run, "bash[apt-get-clean]", :immediately
+end
+
+bash "chef-server-ctl restart" do
+  code "chef-server-ctl restart"
+  only_if { chef_server_configured? }
+end
+
+# Chef Reporting
+chef_ingredient "reporting" do
+  action :upgrade
+
+  notifies :run, "bash[chef-server-ctl start]", :immediately
+  notifies :run, "bash[opscode-reporting-ctl reconfigure]", :immediately
+  notifies :run, "bash[chef-server-ctl restart]"
+  notifies :run, "ruby_block[remove-reporting-from-cache]", :immediately
+  notifies :run, "bash[yum-clean-all]", :immediately
+  notifies :run, "bash[apt-get-clean]", :immediately
+end
+
+# Chef Manage
+bash "chef-manage-ctl stop" do
+  code "chef-manage-ctl stop"
+  retries 3 # sometimes the worker takes a couple tries to die
+  only_if { chef_server_configured? }
 end
 
 chef_ingredient "manage" do
   action :upgrade
 
-  if chef_server_configured?
-    notifies :run, "bash[chef-server-ctl start]", :immediately
-    notifies :run, "bash[chef-manage-ctl reconfigure]", :immediately
-    notifies :run, "bash[chef-manage-ctl restart]", :immediately
-    notifies :run, "bash[chef-server-ctl restart]"
-  end
+  notifies :run, "bash[chef-server-ctl start]", :immediately
+  notifies :run, "bash[chef-manage-ctl reconfigure]", :immediately
+  notifies :run, "bash[chef-server-ctl restart]"
+  notifies :run, "ruby_block[remove-manage-from-cache]", :immediately
+  notifies :run, "bash[yum-clean-all]", :immediately
+  notifies :run, "bash[apt-get-clean]", :immediately
 end
 
-chef_ingredient "reporting" do
-  action :upgrade
-
-  if chef_server_configured?
-    notifies :run, "bash[chef-server-ctl start]", :immediately
-    notifies :run, "bash[opscode-reporting-ctl reconfigure]", :immediately
-    notifies :run, "bash[chef-server-ctl restart]"
-  end
+bash "chef-manage-ctl restart" do
+  code "chef-manage-ctl restart"
+  only_if { chef_server_configured? }
 end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_upgrade_compliance.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_upgrade_compliance.rb
@@ -1,9 +1,32 @@
-chef_ingredient "compliance" do
-  action :upgrade
-  notifies :run, "bash[chef-compliance-ctl reconfigure]", :immediately if compliance_configured?
-end
-
 bash "chef-compliance-ctl reconfigure" do
   code "chef-compliance-ctl reconfigure"
+  only_if { compliance_configured? }
   action :nothing
+end
+
+ruby_block "remove-compliance-from-cache" do
+  block do
+    package = Dir["#{Chef::Config[:file_cache_path]}/*"].find { |f| f =~ /chef-compliance/ }
+    FileUtils.rm(package) if package && File.exist?(package)
+  end
+
+  action :nothing
+end
+
+bash "chef-compliance-ctl stop" do
+  code "chef-compliance-ctl stop"
+  only_if { compliance_configured? }
+end
+
+chef_ingredient "compliance" do
+  action :upgrade
+  notifies :run, "bash[chef-compliance-ctl reconfigure]", :immediately
+  notifies :run, "ruby_block[remove-compliance-from-cache]", :immediately
+  notifies :run, "bash[yum-clean-all]", :immediately
+  notifies :run, "bash[apt-get-clean]", :immediately
+end
+
+bash "chef-compliance-ctl start" do
+  code "chef-compliance-ctl start"
+  only_if { compliance_configured? }
 end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/upgrade.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/upgrade.rb
@@ -5,6 +5,16 @@ unless mirrors_reachable?
   return
 end
 
-node["chef-marketplace"]["upgrade_packages"].each do |pkg|
+bash "yum-clean-all" do
+  code "yum clean all"
+  only_if { node["platform_family"] == "rhel" }
+end
+
+bash "apt-get-clean" do
+  code "apt-get clean"
+  only_if { node["platform"] == "ubuntu" }
+end
+
+node["chef-marketplace"]["upgrade_packages"].sort.each do |pkg|
   include_recipe "chef-marketplace::_upgrade_#{pkg.tr('-', '_')}"
 end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/templates/default/motd.erb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/templates/default/motd.erb
@@ -17,25 +17,16 @@ ________/\\\\\\\\\__/\\\________/\\\__/\\\\\\\\\\\\\\\__/\\\\\\\\\\\\\\\_
 
         Welcome to the <%= @role_name %> Marketplace Appliance!
 
-<% if @role == 'compliance' %>
-If this your first time logging in you'll need to set up Chef Compliance:
-<%= @compliance_url %>
-<% else %>
-If this your first time logging in you'll need to set up <%= @role_name %> by
-running the following command:
-
-sudo chef-marketplace-ctl setup
-<% end -%>
+If you have not completed setting up the <%= @role_name %> please run through
+the setup wizard: <%= @setup_wizard %>
 
 Read Chef documentation: <%= @doc_url %>
 Email the Chef support team: <%= @support_email %>
-<% if @manage_url %>
+<% if @role =~ /aio|server/ %>
 Login to Chef Manage: <%= @manage_url %>
-<% end -%>
-<% if @analytics_url %>
+<% elsif @role == "analytics" %>
 Login to Chef Analytics: <%= @analytics_url %>
-<% end -%>
-<% if @compliance_url %>
+<% elsif @role == "compliance" %>
 Login to Chef Compliance: <%= @compliance_url %>
 <% end -%>
 <% if @update_motd %>


### PR DESCRIPTION
* Update MOTD to point to the proper setup wizards
* License acceptance is done via the setup wizards so add license files to bypass reconfigure checks
* Update chef-ingredient to use packages.chef.io
* Prune the package and chef cache because our root disk can be small
* Automatically stop and start services during upgrade
