### PR TITLE
chef-automate: don't preconfigure

### DIFF
--- a/files/chef-marketplace-cookbooks/chef-marketplace/libraries/helpers.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/libraries/helpers.rb
@@ -352,6 +352,13 @@ class Marketplace
       }
     end
 
+    def marketplace_state_files
+      %w{
+        /etc/chef-marketplace/chef-marketplace-running.json
+        /etc/chef-marketplace/chef-marketplace-secrets.json
+      }
+    end
+
     def compliance_state_files
       %w{
         /etc/chef-compliance/chef-compliance-running.json

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_automate_preconfigure.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_automate_preconfigure.rb
@@ -1,15 +1,3 @@
-%w{delivery-ctl chef-server-ctl}.each do |ctl_cmd|
-  bash "#{ctl_cmd} reconfigure" do
-    code "#{ctl_cmd} reconfigure"
-  end
-end
-
-%w{chef-server-ctl delivery-ctl}.each do |ctl_cmd|
-  bash "#{ctl_cmd} stop" do
-    code "#{ctl_cmd} stop"
-  end
-end
-
 server_state_files.each do |state_file|
   file state_file do
     action :delete
@@ -33,6 +21,12 @@ automate_state_directories.each do |state_dir|
   directory state_dir do
     action :delete
     recursive true
+  end
+end
+
+marketplace_state_files.each do |state_file|
+  file state_file do
+    action :delete
   end
 end
 


### PR DESCRIPTION
right now when running a preconfigure in the build instance we'll
fail to configure certain portions of the automate and chef-server
services beacuse licensing restrictions put the load balancer into
maintencance mode without the presence of a valid license.

eventually we can preconfigure all of the services and then rotate
credentials on first boot, but for now this still cuts down on the
initial install time considerably from needing to install the
packages after boot

/cc @ryancragun 