### PR TITLE
[MAR-18] back-compat for aio upgrades

### DIFF
--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_aio_enable.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_aio_enable.rb
@@ -1,4 +1,4 @@
-include_recipe "chef-marketplace::_server_enable"
+include_recipe "chef-marketplace::_server_aio_enable"
 include_recipe "chef-marketplace::_analytics_enable"
 
 template "/etc/opscode-analytics/opscode-analytics.rb" do

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_server_aio_enable.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_server_aio_enable.rb
@@ -1,0 +1,67 @@
+# Add chef-server-ctl marketplace-setup shim for backwards compatability
+directory "/opt/opscode/embedded/service/omnibus-ctl" do
+  owner "root"
+  group "root"
+  recursive true
+  action :create
+end
+
+file "/opt/opscode/embedded/service/omnibus-ctl/marketplace_setup.rb" do
+  owner "root"
+  group "root"
+  content <<'EOF'
+add_command_under_category 'marketplace-setup', 'marketplace', 'Set up the Chef Server Marketplace Appliance', 2 do
+  run_command("chef-marketplace-ctl setup #{ARGV[1..-1].join(' ')}")
+end
+EOF
+  action :create
+end
+
+template "/etc/cron.d/reporting-partition-cleanup" do
+  source "reporting-partition-cleanup.erb"
+  variables(
+    expression: node["chef-marketplace"]["reporting"]["cron"]["expression"],
+    year: node["chef-marketplace"]["reporting"]["cron"]["year"],
+    month: node["chef-marketplace"]["reporting"]["cron"]["month"]
+  )
+  action reporting_partition_action
+end
+
+directory "/etc/opscode" do
+  owner "opscode"
+  group "opscode"
+  action :create
+end
+
+template "/etc/opscode/chef-server.rb" do
+  source "chef-server-aio.rb.erb"
+  owner "opscode"
+  group "opscode"
+  action :create_if_missing
+end
+
+directory "/etc/chef-manage" do
+  owner "opscode"
+  group "opscode"
+  action :create
+end
+
+template "/etc/chef-manage/manage.rb" do
+  source "manage.rb.erb"
+  owner "opscode"
+  group "opscode"
+  action :create_if_missing
+end
+
+["opscode", "chef-manage", "opscode-reporting"].map do |package|
+  "/var/opt/#{package}/.license.accepted"
+end.each do |license_file|
+  directory ::File.dirname(license_file) do
+    action :create
+  end
+
+  file license_file do
+    action :touch
+    not_if { ::File.exist?(license_file) }
+  end
+end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_upgrade_chef_server_aio.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_upgrade_chef_server_aio.rb
@@ -1,0 +1,83 @@
+# Possibly run actions
+bash "chef-server-ctl reconfigure" do
+  code "chef-server-ctl reconfigure"
+  only_if { chef_server_configured? }
+  action :nothing
+end
+
+bash "chef-server-ctl upgrade" do
+  code "chef-server-ctl upgrade"
+  only_if { chef_server_configured? }
+  action :nothing
+end
+
+bash "chef-server-ctl start" do
+  code "chef-server-ctl start"
+  only_if { chef_server_configured? }
+  action :nothing
+end
+
+bash "opscode-reporting-ctl reconfigure" do
+  code "opscode-reporting-ctl reconfigure"
+  only_if { chef_server_configured? }
+  action :nothing
+end
+
+bash "chef-manage-ctl reconfigure" do
+  code "chef-manage-ctl reconfigure"
+  only_if { chef_server_configured? }
+  action :nothing
+end
+
+# Chef Server
+bash "chef-server-ctl stop" do
+  code "chef-server-ctl stop"
+  only_if { chef_server_configured? }
+end
+
+chef_ingredient "chef-server" do
+  action :upgrade
+
+  notifies :run, "bash[chef-server-ctl reconfigure]", :immediately
+  notifies :run, "bash[chef-server-ctl upgrade]", :immediately
+  notifies :run, "bash[yum-clean-all]", :immediately
+  notifies :run, "bash[apt-get-clean]", :immediately
+end
+
+bash "chef-server-ctl restart" do
+  code "chef-server-ctl restart"
+  only_if { chef_server_configured? }
+end
+
+# Chef Reporting
+chef_ingredient "reporting" do
+  action :upgrade
+
+  notifies :run, "bash[chef-server-ctl start]", :immediately
+  notifies :run, "bash[opscode-reporting-ctl reconfigure]", :immediately
+  notifies :run, "bash[chef-server-ctl restart]"
+  notifies :run, "bash[yum-clean-all]", :immediately
+  notifies :run, "bash[apt-get-clean]", :immediately
+end
+
+# Chef Manage
+bash "chef-manage-ctl stop" do
+  code "chef-manage-ctl stop"
+  retries 3 # sometimes the worker takes a couple tries to die
+  only_if { chef_server_configured? }
+end
+
+chef_ingredient "manage" do
+  action :upgrade
+
+  notifies :run, "bash[chef-server-ctl start]", :immediately
+  notifies :run, "bash[chef-manage-ctl reconfigure]", :immediately
+  notifies :run, "bash[chef-server-ctl restart]"
+  notifies :run, "bash[yum-clean-all]", :immediately
+  notifies :run, "bash[apt-get-clean]", :immediately
+end
+
+bash "chef-manage-ctl restart" do
+  code "chef-manage-ctl restart"
+  only_if { chef_server_configured? }
+end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/templates/default/chef-server-aio.rb.erb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/templates/default/chef-server-aio.rb.erb
@@ -1,0 +1,8 @@
+################################### WARNING ###################################
+#                                                                             #
+# This file is managed by chef-marketplace.  Please consult the documentation #
+# before editing this file as several settings may be overwritten.            #
+#                                                                             #
+###############################################################################
+
+topology 'chef-marketplace'

--- a/files/chef-marketplace-ctl-commands/spec/upgrade_ctl_spec.rb
+++ b/files/chef-marketplace-ctl-commands/spec/upgrade_ctl_spec.rb
@@ -77,14 +77,14 @@ describe "chef-marketplace-ctl upgrade" do
 
       context "when the role is a chef server" do
         let(:role) { "server" }
-        let(:required_packages) { %w{chef-marketplace chef-server} }
+        let(:required_packages) { %w{chef-marketplace chef-server-aio} }
 
         it_behaves_like "a proper upgrade"
       end
 
       context "when the role is an All-In-One" do
         let(:role) { "aio" }
-        let(:required_packages) { %w{chef-marketplace chef-server analytics} }
+        let(:required_packages) { %w{chef-marketplace chef-server-aio analytics} }
 
         it_behaves_like "a proper upgrade"
       end
@@ -95,10 +95,17 @@ describe "chef-marketplace-ctl upgrade" do
 
         it_behaves_like "a proper upgrade"
       end
+
+      context "when the role is automate" do
+        let(:role) { "automate" }
+        let(:required_packages) { %w{chef-marketplace automate chef-server} }
+
+        it_behaves_like "a proper upgrade"
+      end
     end
 
     context "when there is no role configured" do
-      let(:required_packages) { %w{chef-marketplace chef-server analytics} }
+      let(:required_packages) { %w{chef-marketplace chef-server-aio analytics} }
 
       it_behaves_like "a proper upgrade"
     end
@@ -106,7 +113,7 @@ describe "chef-marketplace-ctl upgrade" do
 
   context "with -s" do
     let(:command) { "upgrade -s" }
-    let(:required_packages) { %w{chef-server} }
+    let(:required_packages) { %w{chef-server-aio} }
 
     it_behaves_like "a proper upgrade"
   end
@@ -128,6 +135,13 @@ describe "chef-marketplace-ctl upgrade" do
   context "with -c" do
     let(:command) { "upgrade -c" }
     let(:required_packages) { %w{compliance} }
+
+    it_behaves_like "a proper upgrade"
+  end
+
+  context "with -d" do
+    let(:command) { "upgrade -d" }
+    let(:required_packages) { %w{automate} }
 
     it_behaves_like "a proper upgrade"
   end

--- a/files/chef-marketplace-ctl-commands/upgrade.rb
+++ b/files/chef-marketplace-ctl-commands/upgrade.rb
@@ -28,7 +28,7 @@ add_command_under_category "upgrade", "Maintenance", "Upgrade or install Chef so
       when "compliance"
         config["chef-marketplace"]["upgrade_packages"] << "compliance"
       when "aio"
-        config["chef-marketplace"]["upgrade_packages"] << "chef-server"
+        config["chef-marketplace"]["upgrade_packages"] << "chef-server-aio"
         config["chef-marketplace"]["upgrade_packages"] << "analytics"
       when "automate"
         config["chef-marketplace"]["upgrade_packages"] << "automate"

--- a/files/chef-marketplace-ctl-commands/upgrade.rb
+++ b/files/chef-marketplace-ctl-commands/upgrade.rb
@@ -22,7 +22,7 @@ add_command_under_category "upgrade", "Maintenance", "Upgrade or install Chef so
 
       case config["chef-marketplace"]["role"]
       when "server"
-        config["chef-marketplace"]["upgrade_packages"] << "chef-server"
+        config["chef-marketplace"]["upgrade_packages"] << "chef-server-aio"
       when "analytics"
         config["chef-marketplace"]["upgrade_packages"] << "analytics"
       when "compliance"
@@ -37,7 +37,11 @@ add_command_under_category "upgrade", "Maintenance", "Upgrade or install Chef so
     end
 
     opts.on("-s", "--server", "Upgrade Chef Server, Chef Reporting and Chef Manage") do
-      config["chef-marketplace"]["upgrade_packages"] << "chef-server"
+      if config["chef-marketplace"]["role"] == "automate"
+        config["chef-marketplace"]["upgrade_packages"] << "chef-server"
+      else
+        config["chef-marketplace"]["upgrade_packages"] << "chef-server-aio"
+      end
     end
 
     opts.on("-a", "--analytics", "Upgrade Chef Analytics") do


### PR DESCRIPTION
copies over previous recipes that handle chef-server AIO
configuration and upgrades and separates them from the
chef-server recieps that are intended for use with automate