### PR TITLE
Require the Resource Group for existing resources

### DIFF
--- a/arm-templates/automate/createUiDefinition.json
+++ b/arm-templates/automate/createUiDefinition.json
@@ -170,10 +170,11 @@
               "domainNameLabel": "Chef Automate FQDN DNS Label"
             },
             "toolTip": {
+              "publicIpAddress": "The public IP Address to use for Chef Automate",
               "domainNameLabel": "The DNS label to use as the Chef Automate FQDN"
             },
             "defaultValue": {
-              "publicIpAddressName": "ChefAutomatePublicIPAddress",
+              "publicIpAddressName": "ChefAutomatePubIP",
               "domainNameLabel": "[basics('Name')]"
             },
             "options": {
@@ -256,8 +257,10 @@
       "diagnosticStorageAccountName": "[steps('VirtualMachineConfig').diagnosticStorageAccount.name]",
       "diagnosticStorageAccountNewOrExisting": "[steps('VirtualMachineConfig').diagnosticStorageAccount.newOrExisting]",
       "diagnosticStorageAccountType": "[steps('VirtualMachineConfig').diagnosticStorageAccount.type]",
+      "diagnosticStorageAccountResourceGroup": "[steps('VirtualMachineConfig').diagnosticStorageAccount.resourceGroup]",
       "location": "[location()]",
       "publicIPAddressName": "[steps('VirtualMachineConfig').publicIpAddress.name]",
+      "publicIPAddressResourceGroup": "[steps('VirtualMachineConfig').publicIpAddress.resourceGroup]",
       "publicIPDnsName": "[steps('VirtualMachineConfig').publicIpAddress.domainNameLabel]",
       "publicIPNewOrExisting": "[steps('VirtualMachineConfig').publicIpAddress.newOrExistingOrNone]",
       "resourceGroupName": "[steps('VirtualMachineConfig').storageAccount.resourceGroup]",
@@ -265,11 +268,13 @@
       "storageAccountName": "[steps('VirtualMachineConfig').storageAccount.name]",
       "storageAccountNewOrExisting": "[steps('VirtualMachineConfig').storageAccount.newOrExisting]",
       "storageAccountType": "[steps('VirtualMachineConfig').storageAccount.type]",
+      "storageAccountResourceGroup": "[steps('VirtualMachineConfig').storageAccount.resourceGroup]",
       "subnetName": "[steps('VirtualMachineConfig').virtualNetwork.subnets.subnet1.name]",
       "subnetPrefix": "[steps('VirtualMachineConfig').virtualNetwork.subnets.subnet1.addressPrefix]",
       "virtualNetworkAddressPrefix": "[steps('VirtualMachineConfig').virtualNetwork.addressPrefix]",
       "virtualNetworkName": "[steps('VirtualMachineConfig').virtualNetwork.name]",
       "virtualNetworkNewOrExisting": "[steps('VirtualMachineConfig').virtualNetwork.newOrExisting]",
+      "virtualNetworkResourceGroup": "[steps('VirtualMachineConfig').virtualNetwork.resourceGroup]",
       "vmName": "[basics('vmName')]",
       "vmSize": "[steps('VirtualMachineConfig').vmSize]"
     }

--- a/arm-templates/automate/mainTemplate.json
+++ b/arm-templates/automate/mainTemplate.json
@@ -48,6 +48,13 @@
       },
       "defaultValue": "Standard_LRS"
     },
+    "diagnosticStorageAccountResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "Resouce Group of the storage account to use for diagnostics"
+      },
+      "defaultValue": ""
+    },
     "imageProduct": {
       "type": "string",
       "metadata": {
@@ -80,6 +87,13 @@
       "metadata": {
         "description": "Name to give to the Public IP address of the machine"
       }
+    },
+    "publicIPAddressResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Public IP Adresseses Resource Group"
+      },
+      "defaultValue": ""
     },
     "publicIPDnsName": {
       "type": "string",
@@ -127,6 +141,13 @@
       },
       "defaultValue": "Standard_LRS"
     },
+    "storageAccountResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "Resouce Group of the storage account to use for Virtual Machine disks"
+      },
+      "defaultValue": ""
+    },
     "subnetName": {
       "type": "string",
       "metadata": {
@@ -158,6 +179,13 @@
         "description": "State whether the virtual network exists or not"
       },
       "defaultValue": "new"
+    },
+    "virtualNetworkResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "Resouce Group of the virtual network"
+      },
+      "defaultValue": ""
     },
     "vmName": {
       "type": "string",
@@ -219,11 +247,14 @@
           "location": {
             "value": "[parameters('location')]"
           },
-          "storageAccountType": {
-            "value": "[parameters('storageAccountType')]"
-          },
           "storageAccountName": {
             "value": "[parameters('storageAccountName')]"
+          },
+          "storageAccountResourceGroup": {
+            "value": "[parameters('storageAccountResourceGroup')]"
+          },
+          "storageAccountType": {
+            "value": "[parameters('storageAccountType')]"
           }
         }
       }
@@ -245,11 +276,14 @@
           "location": {
             "value": "[parameters('location')]"
           },
-          "storageAccountType": {
-            "value": "[parameters('diagnosticStorageAccountType')]"
-          },
           "storageAccountName": {
             "value": "[parameters('diagnosticStorageAccountName')]"
+          },
+          "storageAccountResourceGroup": {
+            "value": "[parameters('diagnosticStorageAccountResourceGroup')]"
+          },
+          "storageAccountType": {
+            "value": "[parameters('diagnosticStorageAccountType')]"
           }
         }
       }
@@ -317,17 +351,20 @@
           "apiVersions": {
             "value": "[variables('apiVersions')]"
           },
+          "dnsLabelPrefix": {
+            "value": "[parameters('publicIPDnsName')]"
+          },
           "location": {
             "value": "[parameters('location')]"
           },
           "publicIPAddressName": {
             "value": "[parameters('publicIPAddressName')]"
           },
+          "publicIPAddressResourceGroup": {
+            "value": "[parameters('publicIPAddressResourceGroup')]"
+          },
           "publicIPAddressType": {
             "value": "Dynamic"
-          },
-          "dnsLabelPrefix": {
-            "value": "[parameters('publicIPDnsName')]"
           }
         }
       }
@@ -346,20 +383,23 @@
           "apiVersions": {
             "value": "[variables('apiVersions')]"
           },
-          "virtualNetworkName": {
-            "value": "[parameters('virtualNetworkName')]"
-          },
           "location": {
             "value": "[parameters('location')]"
           },
-          "vnetAddressPrefix": {
-            "value": "[parameters('virtualNetworkAddressPrefix')]"
+          "subnetPrefix": {
+            "value": "[parameters('subnetPrefix')]"
           },
           "subnetName": {
             "value": "[parameters('subnetName')]"
           },
-          "subnetPrefix": {
-            "value": "[parameters('subnetPrefix')]"
+          "virtualNetworkName": {
+            "value": "[parameters('virtualNetworkName')]"
+          },
+          "virtualNetworkResourceGroup": {
+            "value": "[parameters('virtualNetworkResourceGroup')]"
+          },
+          "virtualNetworkAddressPrefix": {
+            "value": "[parameters('virtualNetworkAddressPrefix')]"
           }
         }
       }
@@ -375,7 +415,8 @@
         "[concat('Microsoft.Network/networkSecurityGroups/', variables('sgName'))]"
       ],
       "properties": {
-        "ipConfigurations": [ {
+        "ipConfigurations": [
+          {
             "name": "ipconfig1",
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
@@ -421,6 +462,9 @@
           "diagnosticStorageAccountName": {
             "value": "[parameters('diagnosticStorageAccountName')]"
           },
+          "diagnosticStorageAccountResourceGroup": {
+            "value": "[reference('DiagnosticStorageAccountSetup').outputs.storageAccountResourceGroup.value]"
+          },
           "fqdn": {
             "value": "[reference('PublicIPAddressSetup').outputs.fqdn.value]"
           },
@@ -444,6 +488,9 @@
           },
           "storageAccountName": {
             "value": "[parameters('storageAccountName')]"
+          },
+          "storageAccountResourceGroup": {
+            "value": "[reference('StorageAccountSetup').outputs.storageAccountResourceGroup.value]"
           },
           "vmName": {
             "value": "[parameters('vmName')]"

--- a/arm-templates/automate/mainTemplateParameters.json
+++ b/arm-templates/automate/mainTemplateParameters.json
@@ -12,7 +12,7 @@
       "value": "password"
     },
     "automateLicenseUri": {
-      "value": "https://github.com/chef-partners/omnibus-marketplace/blob/ryan/cloud-283/files/chef-marketplace-cookbooks/chef-marketplace/files/default/delivery.license?raw=true"
+      "value": "https://github.com/chef-partners/omnibus-marketplace/blob/master/files/chef-marketplace-cookbooks/chef-marketplace/files/default/delivery.license?raw=true"
     },
     "diagnosticStorageAccountName": {
       "value": "automatediagstorage"
@@ -81,7 +81,7 @@
       "value": "Standard_D2_v2"
     },
     "baseUrl": {
-      "value": "https://raw.githubusercontent.com/chef-partners/omnibus-marketplace/ryan/cloud-283/arm-templates/automate"
+      "value": "https://raw.githubusercontent.com/chef-partners/omnibus-marketplace/master/arm-templates/automate"
     }
   }
 }

--- a/arm-templates/automate/nested/publicipaddress_existing.json
+++ b/arm-templates/automate/nested/publicipaddress_existing.json
@@ -8,18 +8,6 @@
         "description": "ARM resource API versions"
       }
     },
-    "publicIPAddressName": {
-      "type": "string",
-      "metadata": {
-        "description": "Name to give to the Public IP Address"
-      }
-    },
-    "publicIPAddressType": {
-      "type": "string",
-      "metadata": {
-        "description": "Type of public ip address"
-      }
-    },
     "dnsLabelPrefix": {
       "type": "string"
     },
@@ -28,16 +16,34 @@
       "metadata": {
         "description": "Azure location for the resource"
       }
+    },
+    "publicIPAddressName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name to give to the Public IP Address"
+      }
+    },
+    "publicIPAddressResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "The Public IP Addresses Resource Group"
+      }
+    },
+    "publicIPAddressType": {
+      "type": "string",
+      "metadata": {
+        "description": "Type of public ip address"
+      }
     }
   },
   "resources": [],
   "outputs": {
     "publicIpId": {
-      "value": "[resourceId(concat('Microsoft.Network','/','publicIPAddresses'),parameters('publicIPAddressName'))]",
+      "value": "[resourceId(parameters('publicIPAddressResourceGroup'), 'Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]",
       "type": "string"
     },
     "fqdn": {
-      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName')), parameters('apiVersions').publicIPAddresses).dnsSettings.fqdn]",
+      "value": "[reference(resourceId(parameters('publicIPAddressResourceGroup'), 'Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName')), parameters('apiVersions').publicIPAddresses).dnsSettings.fqdn]",
       "type": "string"
     }
   }

--- a/arm-templates/automate/nested/publicipaddress_new.json
+++ b/arm-templates/automate/nested/publicipaddress_new.json
@@ -8,18 +8,6 @@
         "description": "ARM resource API versions"
       }
     },
-    "publicIPAddressName": {
-      "type": "string",
-      "metadata": {
-        "description": "Name to give to the Public IP Address"
-      }
-    },
-    "publicIPAddressType": {
-      "type": "string",
-      "metadata": {
-        "description": "Type of public ip address"
-      }
-    },
     "dnsLabelPrefix": {
       "type": "string"
     },
@@ -27,6 +15,24 @@
       "type": "string",
       "metadata": {
         "description": "Azure location for the resource"
+      }
+    },
+    "publicIPAddressName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name to give to the Public IP Address"
+      }
+    },
+    "publicIPAddressResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "The Public IP Addresses Resource Group"
+      }
+    },
+    "publicIPAddressType": {
+      "type": "string",
+      "metadata": {
+        "description": "Type of public ip address"
       }
     }
   },
@@ -50,7 +56,7 @@
   ],
   "outputs": {
     "publicIpId": {
-      "value": "[resourceId(concat('Microsoft.Network','/','publicIPAddresses'),parameters('publicIPAddressName'))]",
+      "value": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]",
       "type": "string"
     },
     "fqdn": {

--- a/arm-templates/automate/nested/storageaccount_existing.json
+++ b/arm-templates/automate/nested/storageaccount_existing.json
@@ -28,10 +28,20 @@
         "Description": "The type of the Storage Account created"
       },
       "defaultValue": "Standard_LRS"
+    },
+    "storageAccountResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "Description": "The Resource Group for the new storage account"
+      }
     }
   },
   "resources": [
   ],
   "outputs": {
+    "storageAccountResourceGroup": {
+      "type": "string",
+      "value": "[parameters('storageAccountResourceGroup')]"
+    }
   }
 }

--- a/arm-templates/automate/nested/storageaccount_new.json
+++ b/arm-templates/automate/nested/storageaccount_new.json
@@ -28,6 +28,12 @@
         "Description": "The type of the Storage Account created"
       },
       "defaultValue": "Standard_LRS"
+    },
+    "storageAccountResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "Description": "The Resource Group for the new storage account"
+      }
     }
   },
   "resources": [
@@ -46,5 +52,9 @@
     }
   ],
   "outputs": {
+    "storageAccountResourceGroup": {
+      "type": "string",
+      "value": "[resourceGroup().name]"
+    }
   }
 }

--- a/arm-templates/automate/nested/vm_password.json
+++ b/arm-templates/automate/nested/vm_password.json
@@ -23,7 +23,13 @@
     "diagnosticStorageAccountName": {
       "type": "string",
       "metadata": {
-        "description": "The name of the storage account to use"
+        "description": "The name of the storage account to use for diagnostics"
+      }
+    },
+    "diagnosticStorageAccountResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "The Resource Group of the diagnostic storage account"
       }
     },
     "imageProduct": {
@@ -80,6 +86,12 @@
         "description": "The name of the storage account to use"
       }
     },
+    "storageAccountResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "The Resource Group of the storage account"
+      }
+    },
     "nicName": {
       "type": "string",
       "metadata": {
@@ -124,7 +136,7 @@
           "osDisk": {
             "name": "[parameters('vmName')]",
             "vhd": {
-              "uri": "[concat(concat(reference(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('apiVersions').storageAccounts).primaryEndpoints['blob'], 'vhds/'), parameters('vmName'), '.vhd')]"
+              "uri": "[concat(concat(reference(resourceId(parameters('storageAccountResourceGroup'), 'Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('apiVersions').storageAccounts).primaryEndpoints['blob'], 'vhds/'), parameters('vmName'), '.vhd')]"
             },
             "caching": "ReadWrite",
             "createOption": "FromImage"
@@ -140,7 +152,7 @@
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": "true",
-            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('diagnosticStorageAccountName')), parameters('apiVersions').storageAccounts).primaryEndpoints['blob']]"
+            "storageUri": "[reference(resourceId(parameters('diagnosticStorageAccountResourceGroup'), 'Microsoft.Storage/storageAccounts', parameters('diagnosticStorageAccountName')), parameters('apiVersions').storageAccounts).primaryEndpoints['blob']]"
           }
         }
       }

--- a/arm-templates/automate/nested/vm_sshPublicKey.json
+++ b/arm-templates/automate/nested/vm_sshPublicKey.json
@@ -26,6 +26,12 @@
         "description": "The name of the storage account to use"
       }
     },
+    "diagnosticStorageAccountResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "The Resource Group of the diagnostic storage account"
+      }
+    },
     "imageProduct": {
       "type": "string",
       "metadata": {
@@ -78,6 +84,12 @@
       "type": "string",
       "metadata": {
         "description": "The name of the storage account to use"
+      }
+    },
+    "storageAccountResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "The Resource Group of the storage account"
       }
     },
     "nicName": {
@@ -135,7 +147,7 @@
           "osDisk": {
             "name": "[parameters('vmName')]",
             "vhd": {
-              "uri": "[concat(concat(reference(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('apiVersions').storageAccounts).primaryEndpoints['blob'], 'vhds/'), parameters('vmName'), '.vhd')]"
+              "uri": "[concat(concat(reference(resourceId(parameters('storageAccountResourceGroup'), 'Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('apiVersions').storageAccounts).primaryEndpoints['blob'], 'vhds/'), parameters('vmName'), '.vhd')]"
             },
             "caching": "ReadWrite",
             "createOption": "FromImage"
@@ -151,7 +163,7 @@
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": "true",
-            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('diagnosticStorageAccountName')), parameters('apiVersions').storageAccounts).primaryEndpoints['blob']]"
+            "storageUri": "[reference(resourceId(parameters('diagnosticStorageAccountResourceGroup'), 'Microsoft.Storage/storageAccounts', parameters('diagnosticStorageAccountName')), parameters('apiVersions').storageAccounts).primaryEndpoints['blob']]"
           }
         }
       }

--- a/arm-templates/automate/nested/vnet_existing.json
+++ b/arm-templates/automate/nested/vnet_existing.json
@@ -20,12 +20,15 @@
     "virtualNetworkName": {
       "type": "string"
     },
-    "vnetAddressPrefix": {
+    "virtualNetworkResourceGroup": {
+      "type": "string"
+    },
+    "virtualNetworkAddressPrefix": {
       "type": "string"
     }
   },
   "variables" : {
-    "vnetID" : "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
+    "vnetID" : "[resourceId(parameters('virtualNetworkResourceGroup'), 'Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
     "subnet" : "[concat(variables('vnetID'), '/subnets/', parameters('subnetName'))]"
   },
   "resources": [

--- a/arm-templates/automate/nested/vnet_new.json
+++ b/arm-templates/automate/nested/vnet_new.json
@@ -20,12 +20,15 @@
     "virtualNetworkName": {
       "type": "string"
     },
-    "vnetAddressPrefix": {
+    "virtualNetworkResourceGroup": {
+      "type": "string"
+    },
+    "virtualNetworkAddressPrefix": {
       "type": "string"
     }
   },
   "variables" : {
-    "vnetID" : "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
+    "vnetID" : "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
     "subnet" : "[concat(variables('vnetID'),'/subnets/',parameters('subnetName'))]"
   },
   "resources": [
@@ -41,7 +44,7 @@
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('vnetAddressPrefix')]"
+            "[parameters('virtualNetworkAddressPrefix')]"
           ]
         },
         "subnets": [


### PR DESCRIPTION
In cases where the Solution Template supports re-using existing
resouces:

* Storage Accounts
* Public IP Adresses
* Virtual Networks

we need to require the Resource Group name when looking up references to
those resources. Previously we assumed all resources would be in our
current Resource Group, however, the UI Elements allow users to specify
matching resource types available in the specified region regardless of
their Resource Group. This resulted in launch failures when the template
tried to reference existing resources that exits in a different resource
group.