### PR TITLE
Hide existing Public IP Addresses in UI definition

### DIFF
--- a/arm-templates/automate/createUiDefinition.json
+++ b/arm-templates/automate/createUiDefinition.json
@@ -178,7 +178,7 @@
               "domainNameLabel": "[basics('Name')]"
             },
             "options": {
-              "hideNone": true
+              "hideExisting": true
             },
             "constraints": {
               "required": {


### PR DESCRIPTION
There's currently an issue with Azure's UI that prevents validation from
succeeding when selecting an existing Public IP Address. There is a
hacky workaround but it isn't obvious and it definitely impacts user
performance. To that end we'll hide existing Public IP Addresses in the
UI definition until the UI bug is resolved.