### PR TITLE
[CLOUD-288] Make Chef Automate expired contact email configurable

### DIFF
--- a/files/chef-marketplace-cookbooks/chef-marketplace/attributes/default.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/attributes/default.rb
@@ -7,6 +7,7 @@
 default["chef-marketplace"].tap do |m|
   m["motd"]["enabled"] = true
   m["support"]["email"] = "aws@chef.io"
+  m["sales"]["email"] = "awesome@chef.io"
   m["documentation"]["url"] = "https://docs.chef.io/aws_marketplace.html"
   m["role"] = "server"
   m["license"]["count"] = 5

--- a/files/chef-marketplace-cookbooks/chef-marketplace/libraries/marketplace.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/libraries/marketplace.rb
@@ -27,6 +27,10 @@ class Marketplace
     default :email, "aws@chef.io"
   end
 
+  config_context :sales do
+    default :email, "awesome@chef.io"
+  end
+
   config_context :documentation do
     default :url, "https://docs.chef.io/aws_marketplace.html"
   end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/templates/default/delivery.rb.erb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/templates/default/delivery.rb.erb
@@ -12,11 +12,12 @@ delivery["chef_server"]           = "https://localhost:8443/organizations/delive
 delivery["chef_server_proxy"]     = true
 delivery["chef_username"]         = "delivery"
 delivery["primary"]               = true
-delivery["marketplace_licensing"] = <%= node['chef-marketplace']['platform'] == 'aws' %>
+delivery["marketplace_licensing"] = <%= node["chef-marketplace"]["platform"] == "aws" %>
 elasticsearch["enable_auth"]      = true
 insights["enable"]                = true
 insights["enable_auth"]           = true
 kibana["enable_auth"]             = true
+nginx["expired_trial_contact"]    = "<%= node["chef-marketplace"]["sales"]["email"] %>"
 postgresql["listen_address"]      = "0.0.0.0"
 postgresql["superuser_enable"]    = true
 postgresql["superuser_username"]  = "chef-pgsql"


### PR DESCRIPTION
Add a sales contact configuration option and automatically set the Chef Automate expired trial contact address to the sales email.