### PR TITLE
automate_setup: handle case with no licesne

### DIFF
--- a/arm-templates/automate/automate_setup.rb
+++ b/arm-templates/automate/automate_setup.rb
@@ -13,7 +13,7 @@ require "fileutils"
 
 OptionParser.new do |opts|
   opts.on("--fqdn FQDN", String, "The machine FQDN") { |fqdn| @fqdn = fqdn }
-  opts.on("--license [LICENSE]", String, "The Automate license file") do |license|
+  opts.on("--license [LICENSE]", "The Automate license file") do |license|
     @license = license
   end
 end.parse!(ARGV)


### PR DESCRIPTION
opt-parser was requiring that we passed a non-empty string
to the command, which is a case that we handle later in
the script. removing this validation fixes the case where
the user does not supply a license

Signed-off-by: Stephen Delano <stephen@chef.io>