### PR TITLE
Fix Chef Server setup and disable Telemetry

### DIFF
--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_automate_enable.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_automate_enable.rb
@@ -29,6 +29,12 @@ directory '/var/opt/delivery/license' do
   recursive true
 end
 
+# Disable telemetry on AWS because it's against the terms 'o service
+file '/var/opt/delivery/.telemetry.disabled' do
+  action :create_if_missing
+  only_if { node['chef-marketplace']['platform'] == 'aws' }
+end
+
 # Use a 30 day trial license if we're on Azure
 cookbook_file 'var/opt/delivery/license/delivery.license' do
   source 'delivery.license'


### PR DESCRIPTION
* Fix a bug where the Chef Server setup would fail because of a
  preflight check bug in the Chef Server.

* Disable Automate Telemetry on AWS because it violates the terms
  of service.