### PR TITLE
[CLOUD-371] Fix pedant tests for Chef Automate AIO

### DIFF
--- a/files/chef-marketplace-cookbooks/chef-marketplace/templates/default/chef-server.rb.erb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/templates/default/chef-server.rb.erb
@@ -13,8 +13,10 @@ data_collector["token"]                     = "<%= node["chef-marketplace"]["aut
 nginx["non_ssl_port"]                       = false
 nginx["ssl_port"]                           = 8443
 nginx["dhparam_key_length"]                 = 1024
+nginx["ssl_protocols"]                      = "TLSv1.2"
 nginx["server_name"]                        = "<%= node["chef-marketplace"]["api_fqdn"] %>"
 oc_id["enable"]                             = false
+oc_chef_pedant["chef_server"]               = "<%= node["chef-marketplace"]["api_fqdn"] %>"
 opscode_erchef["base_resource_url"]         = "https://<%= node["chef-marketplace"]["api_fqdn"] %>"
 opscode_erchef["nginx_bookshelf_caching"]   = :on
 opscode_erchef["s3_url_expiry_window_size"] = "50%"


### PR DESCRIPTION
This change overrides the Chef server pedant configuration exclude the
Chef Server's non-default SSL port. That will allow the tests to run
through the Chef Automate proxy and into the Chef Server.

It also limits SSL to TLSv1.2, which is fine because SSL is terminated
on the Chef Automate nginx. It also fixes a bug where some pedant tests
would attempt to use TLSv1.0 against the Automate nginx and it was
rejected.

Requires a stable release of the Chef Server including that includes https://github.com/chef/chef-server/pull/1278 