### PR TITLE
Azure Stack compatibility for Chef Automate solution template

### DIFF
--- a/arm-templates/automate/mainTemplate.json
+++ b/arm-templates/automate/mainTemplate.json
@@ -210,14 +210,14 @@
   },
   "variables": {
     "apiVersions": {
-      "deployments": "2016-09-01",
-      "networkInterfaces": "2017-03-01",
-      "networkSecurityGroups": "2016-12-01",
-      "publicIPAddresses": "2017-03-01",
-      "storageAccounts": "2016-12-01",
-      "virtualMachineExtensions": "2017-03-30",
-      "virtualMachines": "2017-03-30",
-      "virtualNetworks": "2017-03-01"
+      "deployments": "2016-06-01",
+      "networkInterfaces": "2015-06-15",
+      "networkSecurityGroups": "2015-06-15",
+      "publicIPAddresses": "2015-06-15",
+      "storageAccounts": "2015-06-15",
+      "virtualMachineExtensions": "2016-03-30",
+      "virtualMachines": "2016-03-30",
+      "virtualNetworks": "2015-06-15"
     },
     "imagePublisher": "chef-software",
     "diagnosticStorageAccountResourceGroupnew": "[resourceGroup().name]",
@@ -552,9 +552,9 @@
         "provider": "[variables('providerGuid')]"
       },
       "properties": {
-        "publisher": "Microsoft.Azure.Extensions",
-        "type": "CustomScript",
-        "typeHandlerVersion": "2.0",
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "CustomScriptForLinux",
+        "typeHandlerVersion": "1.3",
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [

--- a/arm-templates/automate/mainTemplate.json
+++ b/arm-templates/automate/mainTemplate.json
@@ -60,7 +60,7 @@
       "metadata": {
         "description": "The name of the product offering"
       },
-      "defaultValue": "chef-automate"
+      "defaultValue": "chef-automate-vm-image"
     },
     "imageSKU": {
       "type": "string",

--- a/arm-templates/automate/mainTemplateParameters.json
+++ b/arm-templates/automate/mainTemplateParameters.json
@@ -27,7 +27,7 @@
       "value": ""
     },
     "imageProduct": {
-      "value": "chef-automate"
+      "value": "chef-automate-vm-image"
     },
     "imageSKU": {
       "value": "byol"

--- a/arm-templates/automate/storageaccount_new.json
+++ b/arm-templates/automate/storageaccount_new.json
@@ -47,10 +47,9 @@
       "name": "[parameters('storageAccountName')]",
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "[parameters('apiVersions').storageAccounts]",
-      "sku": {
-        "name": "[parameters('storageAccountType')]"
+      "properties":{
+        "accountType": "[parameters('storageAccountType')]"
       },
-      "kind": "Storage",
       "location": "[parameters('location')]",
       "tags": {
         "project": "Chef Automate",


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

This change allows the existing Chef Automate solution template to be compatible with the Azure Resource Provider versions used in the TP3 refresh of Azure Stack, by downgrading some of the API versions used in the ARM template to match those deployed on Azure Stack.  

These changes will need to be staged in the usual manner prior to validation.  We already have sign off from Greg Oliver and Matt McSpirit that these are valid changes.

```
From: Matt McSpirit
Sent: 05 June 2017 22:03
To: Stuart Preston; Greg Oliver
Subject: RE: Catch-Up

Hey Stuart,

The engineers seem to think all the JSON templates look good, and advised for you to test
on Azure with the updated template.  All being well, and the testing works out fine, you should
be good to start the publish process of these updated assets to the Azure Marketplace.  Once
that’s done, the guys will help us turn it on for syndication.

Thanks!
Matt
```

One tested and listed on the Public Marketplace, we can reply to Matt McSpirit <matt.mcspirit@microsoft.com> who will help enable the syndication to Azure Stack.
