### PR TITLE
Fix support for chef 13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,4 +98,7 @@ arm-test:
 arm-create-zip:
 	cd ./arm-templates/automate && zip -r "../../automate_arm_`date -u +"%Y-%m-%dT%H:%M:%SZ"`.zip" ./*
 
+run-chef-client-test:
+	docker-compose -f docker-compose-tests.yml run chef-client-test
+
 .PHONY: clean start test

--- a/docker-compose-services.yml
+++ b/docker-compose-services.yml
@@ -1,0 +1,69 @@
+version: '2'
+services:
+  # This is Automate in "Marketplace mode" which consists of:
+  #  * Chef Server
+  #  * Chef Automate
+  #  * Chef Marketplace
+  automate:
+    hostname: automate-marketplace
+    privileged: true # for iptables
+    image: devchef/chef-server-12
+    mem_limit: 4G
+    expose:
+      - "22"
+      - "443"
+      # Git Port
+      - "8989"
+      # Push Job Ports
+      - "10000-10003"
+    ports:
+      - "443:443" # workflow/viz UI
+    volumes:
+      - ./shared:/shared
+      - ./.chef/keys:/volumes/keys # mount chef-server keys to host for knife
+      - ./files/chef-marketplace-ctl-commands:/sync/ctl-commands
+      - ./files/chef-marketplace-cookbooks:/sync/marketplace-cookbooks
+      - ./files/chef-marketplace-gem:/sync/chef-marketplace-gem
+      - ./files/reckoner:/sync/reckoner
+      - ./files/biscotti:/sync/biscotti
+      - ./pkg:/omnibus-pkgs
+    environment:
+      # override devchef/chef-server-12 defaults
+      - CHEF_FQDN=automate-marketplace.test
+      - CHEF_USER=delivery
+      - CHEF_NAME=Delivery User
+      - CHEF_ORG_SHORT=acme
+      - CHEF_ORG_FULL=Acme Co
+      # Marketplace package
+      - CHANNEL=${CHANNEL}
+      - VERSION=${VERSION}
+      - U_CHANNEL=${U_CHANNEL}
+      - U_VERSION=${U_VERSION}
+      # Chef Automate
+      - CA_CHANNEL=${CA_CHANNEL}
+      # Chef Server
+      - CS_CHANNEL=${CS_CHANNEL}
+    command: bash -c /shared/scripts/automate-marketplace.sh
+  # This is a simple sinatra app that will act as an ec2 metadata server which
+  # will allow us to to mimick being in ec2.
+  ec2-metadata:
+    image: devchef/chefdk:latest
+    ports:
+      - "9666:9666"
+    volumes:
+      - ./shared/scripts/ec2-metadata.sh:/usr/src/ec2-metadata.sh
+    command: bash /usr/src/ec2-metadata.sh
+  # This is a chef-client that's configured to converge against our test
+  # server. It includes the `audit` cookbook to ensure that we're compliance
+  # data is being sent and includes runs the latest version
+  # automate-liveness-agent to send node_pings
+  chef-client-test:
+    networks:
+      marketplace:
+        ipv4_address: 172.16.239.5
+        aliases:
+          - chef-client.test
+    image: devchef/chefdk:latest
+    volumes:
+      - ./shared/:/shared
+    command: bash /shared/scripts/chef-client-test.sh

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -14,6 +14,19 @@ networks:
           gateway: 172.16.239.1
 
 services:
+  chef-client-test:
+    extends:
+      file: docker-compose-services.yml
+      service: chef-client-test
+    networks:
+      marketplace:
+        ipv4_address: 172.16.239.5
+        aliases:
+          - chef-client.test
+    links:
+      - automate:automate
+    depends_on:
+      - automate
   automate:
     extends:
       file: docker-compose-services.yml

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_config_api_fqdn.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_config_api_fqdn.rb
@@ -6,7 +6,7 @@
 
 return if node["chef-marketplace"]["api_fqdn"]
 
-node.default["chef-marketplace"]["api_fqdn"] =
+node.normal["chef-marketplace"]["api_fqdn"] =
   if node.key?("cloud_v2") && !node["cloud_v2"].nil?
     if node["cloud_v2"]["provider"] == "gce"
       node["cloud_v2"]["public_ipv4"] if node["cloud_v2"]["public_ipv4"] && !node["cloud_v2"]["public_ipv4"].empty?

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_config_package_mirrors.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_config_package_mirrors.rb
@@ -7,8 +7,8 @@ when "redhat"
   end
 when "centos"
   %w{base extras plus updates}.each do |repo|
-    node.default["yum"][repo]["enabled"] = true
-    node.default["yum"][repo]["managed"] = true
+    node.normal["yum"][repo]["enabled"] = true
+    node.normal["yum"][repo]["managed"] = true
   end
 
   include_recipe "yum-centos::default"

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_config_reckoner.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_config_reckoner.rb
@@ -1,7 +1,7 @@
 if node["chef-marketplace"]["role"] =~ /aio|server|automate/
-  node.default["chef-marketplace"]["reckoner"]["usage_dimension"] = "ChefNodes"
+  node.normal["chef-marketplace"]["reckoner"]["usage_dimension"] = "ChefNodes"
 elsif node["chef-marketplace"]["role"] == "compliance"
-  node.default["chef-marketplace"]["reckoner"]["usage_dimension"] = "ComplianceNodes"
+  node.normal["chef-marketplace"]["reckoner"]["usage_dimension"] = "ComplianceNodes"
 end
 
-node.default["chef-marketplace"]["reckoner"]["enabled"] if node["chef-marketplace"]["license"]["type"] == "flexible"
+node.normal["chef-marketplace"]["reckoner"]["enabled"] if node["chef-marketplace"]["license"]["type"] == "flexible"

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_security.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_security.rb
@@ -10,7 +10,7 @@ sshd_config_mode = node["platform_family"] == "rhel" ? "0600" : "0644"
   end
 end
 
-node.default["openssh"]["server"]["client_alive_interval"] = 180 if node["chef-marketplace"]["platform"] == "azure"
+node.normal["openssh"]["server"]["client_alive_interval"] = 180 if node["chef-marketplace"]["platform"] == "azure"
 
 template "/etc/ssh/sshd_config" do
   source "sshd-config.erb"

--- a/shared/recipes/chef-client-test.rb
+++ b/shared/recipes/chef-client-test.rb
@@ -1,0 +1,17 @@
+directory '/etc/chef' do
+  recursive true
+end
+
+file '/etc/chef/client.rb' do
+  content <<-EOS.gsub(/^\s+/, '')
+    log_location     STDOUT
+    chef_server_url  'https://automate-marketplace.test/organizations/test'
+    node_name        'test-node'
+    ssl_verify_mode  :verify_none
+    client_key       '/shared/keys/test.pem'
+  EOS
+end
+
+execute 'chef-client' do
+  live_stream true
+end

--- a/shared/recipes/setup-chef-client-test.rb
+++ b/shared/recipes/setup-chef-client-test.rb
@@ -1,0 +1,100 @@
+require 'cheffish'
+
+# Create a key that we'll use for org, admin user, and client.
+private_key '/shared/keys/test.pem' do
+  cipher            'DES-EDE3-CBC'
+  format            :pem
+  public_key_format :openssh
+  public_key_path   '/shared/keys/test.pub'
+  size              2048
+  type              :rsa
+end
+
+Chef::Config[:ssl_verify_mode] = :verify_none
+
+# Bootstrap an organization and admin user as pivotal
+with_chef_server 'https://127.0.0.1:8443',
+  client_name: 'pivotal',
+  signing_key_filename: '/etc/opscode/pivotal.pem' do
+
+  chef_user 'test-admin' do
+    user_name 'test-admin'
+    display_name 'test-admin'
+    admin true
+    email 'test-admin@chef.io'
+    password 'password123!'
+    source_key_path '/shared/keys/test.pem'
+    retries 3
+  end
+
+  chef_organization 'test' do
+    full_name 'test'
+    retries 3
+    members %w(test-admin)
+  end
+
+  chef_acl '/organizations/test/containers/clients' do
+    rights :all, users: 'test-admin'
+  end
+end
+
+# Bootstrap a client as the admin user
+with_chef_server 'https://127.0.0.1/organizations/test',
+  client_name: 'test-admin',
+  signing_key_filename: '/shared/keys/test.pem' do
+
+  chef_client 'test-node' do
+    source_key_path '/shared/keys/test.pem'
+    retries 3
+  end
+end
+
+# Bootstrap a node as the client
+with_chef_server 'https://127.0.0.1/organizations/test',
+  client_name: 'test-node',
+  signing_key_filename: '/shared/keys/test.pem' do
+
+  chef_node 'test-node' do
+    run_list %w(audit)
+    attributes(
+      'audit' => {
+        'reporter' => 'chef-server-automate',
+        'inspec_version' => '1.31.1',
+        'profiles' => [
+          { 'name' => 'linux', 'url' => 'https://github.com/dev-sec/linux-baseline/archive/2.1.0.zip' },
+        ],
+      }
+    )
+  end
+end
+
+directory '/root/.chef' do
+  recursive true
+end
+
+file '/root/.chef/knife.rb' do
+  content <<-EOS.gsub(/^\s+/, '')
+    log_location     STDOUT
+    chef_server_url  'https://automate-marketplace.test/organizations/test'
+    node_name        'test-admin'
+    ssl_verify_mode  :verify_none
+    client_key       '/shared/keys/test.pem'
+  EOS
+end
+
+file '/etc/chef/Berksfile' do
+  content <<-EOS.gsub(/^\s+/, '')
+    source "https://supermarket.chef.io"
+
+    cookbook "audit", ">= 4.1.1"
+  EOS
+end
+
+bash 'upload-cookbooks' do
+  code <<-EOS.gsub(/^\s+/, '')
+    berks install -b /etc/chef/Berksfile
+    berks upload --no-ssl-verify -b /etc/chef/Berksfile
+  EOS
+
+  live_stream true
+end

--- a/shared/scripts/automate-marketplace.sh
+++ b/shared/scripts/automate-marketplace.sh
@@ -35,6 +35,9 @@ if [ ! -z ${metadata_ip} ]; then
   iptables -t nat -p tcp -A OUTPUT -d 169.254.169.254 -j DNAT --to-destination ${metadata_ip}:9666
 fi
 
+# Please chef-server-ctl's preflight checks
+sysctl -w net.ipv6.conf.lo.disable_ipv6=0
+
 # Make chef-client think we're in ec2
 mkdir -p /etc/chef/ohai/hints
 touch /etc/chef/ohai/hints/ec2.json
@@ -69,6 +72,9 @@ else
   chef-marketplace-ctl setup --preconfigure
   touch /var/opt/chef-marketplace/preconfigured
 fi
+
+# Setup chef-client-test
+/opt/chefdk/bin/chef-apply /shared/recipes/setup-chef-client-test.rb
 
 # Something useful that also keeps the container running...
 chef-marketplace-ctl tail

--- a/shared/scripts/chef-client-test.sh
+++ b/shared/scripts/chef-client-test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/opt/chefdk/bin/chef-apply /shared/recipes/chef-client-test.rb


### PR DESCRIPTION
Use `node.normal` attribute precedence where we previously used `node.set`.
Add support for converging a chef-client against the development environment.