### PR TITLE
[CLOUD-474] Fix reckoner for Automate 1.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "chefstyle"
 
 # Reckoner Deps
 gem "sequel"
-gem "aws-sdk"
+gem "aws-sdk", "~> 2"
 
 group :development do
   # Use Test Kitchen with Vagrant for converging the build environment

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk
+  aws-sdk (~> 2)
   berkshelf
   chef
   chefstyle

--- a/files/chef-marketplace-gem/chef-marketplace.gemspec
+++ b/files/chef-marketplace-gem/chef-marketplace.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pg"
   spec.add_dependency "highline"
   spec.add_dependency "chef", "~>13"
-  spec.add_dependency "aws-sdk"
-  spec.add_dependency "elasticsearch"
+  spec.add_dependency "aws-sdk", "~> 2"
+  spec.add_dependency "elasticsearch", "~> 5"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/files/chef-marketplace-gem/lib/marketplace/reckoner/checker/automate.rb
+++ b/files/chef-marketplace-gem/lib/marketplace/reckoner/checker/automate.rb
@@ -18,8 +18,6 @@ class Marketplace
         end
 
         def current_usage
-          count = 0
-
           # Limit our result set to 100 nodes and allow the scrolling identifier
           # to exist for 5 minutes.
           result = es.search(
@@ -29,13 +27,17 @@ class Marketplace
             size: "100",
             body: {
               query: {
-                filtered: {
-                  filter: { term: { exists: "true" } },
+                bool: {
+                  must: {
+                    term: { exists: "true" },
+                  },
                 },
               },
               _source: %w{checkin},
             }
           )
+
+          count = result["hits"]["hits"].count
 
           # Iterate over our our search collection and count the active nodes
           loop do

--- a/files/reckoner/Gemfile
+++ b/files/reckoner/Gemfile
@@ -5,3 +5,4 @@ gem "chef-marketplace" #, path: File.expand_path("../chef-marketplace-gem")
 gem "pg"
 gem "clockwork"
 gem "elasticsearch"
+gem "aws-sdk", "~> 2"


### PR DESCRIPTION
* Make the reckoner nodes query ES 5 compatible
* Pin the AWS SDK to version 2 until omnibus is updated and reckoner is
  migrated.