### PR TITLE
Added support for Alibaba cloud platform

### DIFF
--- a/files/chef-marketplace-cookbooks/chef-marketplace/attributes/default.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/attributes/default.rb
@@ -52,6 +52,10 @@ default["chef-marketplace"].tap do |m|
   m["biscotti"]["enabled"] = false
   m["biscotti"]["port"] = 9666
   m["biscotti"]["listen_address"] = "127.0.0.1"
+  m["product_urls"] = {
+    'automate' => 'http://chef-software.oss-cn-beijing.aliyuncs.com/automate_1.6.95-1_amd64.deb',
+    'chef_server' => 'http://chef-software.oss-cn-beijing.aliyuncs.com/chef-server-core_12.15.8-1_amd64.deb',
+  }
 end
 
 default["enterprise"]["name"] = "chef-marketplace"

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_config_biscotti.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_config_biscotti.rb
@@ -20,7 +20,7 @@ uuid_type, uuid =
   case node['chef-marketplace']['platform']
   when 'google'
     ['Project Name', node['gce']['project']['projectId']]
-  when 'azure'
+  when 'azure', 'alibaba'
     ['VM Name', node['hostname']]
   else # aws, testing
     ['Instance ID', node['ec2']['instance_id']]

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_publishing_enable.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_publishing_enable.rb
@@ -22,6 +22,8 @@ user node["chef-marketplace"]["user"] do
   home "/home/#{node['chef-marketplace']['user']}"
   shell "/bin/bash"
   action [:create, :lock]
+
+  not_if { node["chef-marketplace"]["user"] == "root" }
 end
 
 package "cloud-init" do

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_upgrade_automate.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_upgrade_automate.rb
@@ -12,8 +12,23 @@ bash 'delivery-ctl start' do
 end
 
 # Chef Automate
+
+# Download the package for installation if running on Alibaba
+if node["chef-marketplace"].key?("product_urls") &&
+   node["chef-marketplace"]["product_urls"].key?("automate")
+  target_path = File.join(Chef::Config[:file_cache_path], File.basename(node["chef-marketplace"]["product_urls"]["automate"]))
+end
+remote_file target_path do
+  source node["chef-marketplace"]["product_urls"]["automate"]
+
+  only_if { node["chef-marketplace"]["platform"] == "alibaba" }
+end
+
 chef_ingredient 'delivery' do
   action :upgrade
+
+  # Use the package sourec if this is running on Alibaba
+  package_source target_path if node["chef-marketplace"]["platform"] == "alibaba"
 
   notifies :run, 'bash[delivery-ctl reconfigure]', :immediately
   notifies :run, 'bash[yum-clean-all]', :immediately


### PR DESCRIPTION
Updated the chef-marketplace cookbook to support the creation of marketplace images on the Alibaba Cloud Platform.

In order to support this the Automate and Chef-Server packages have been uploaded to the Object Storage Server (OSS) which is the Alibaba equivalent to AWS S3. This has been done because pulling packages from the `packages.chef.io` is so slow that the operation times out.

To get this working I have hardcoded the `product_urls` into the default attributes file because I could not work out how to pass additional configuration from Packer in the `marketplace-image` as attributes to this cookbook. Is it because they are nested because the `platform` comes through ok?

Then to install the packages I have added a remote_file resource to the `_upgrade_automate.rb` and `_update_chef_server.rb` that only triggers when the platform is "Alibaba" so that the DEB file is downloaded from OSS. The subsequent `chfe-ingredient` resource then has the `package_source` attribute set if the platform is "Alibaba".

A small modification was required to the `_config_biscotti.rb` file so that it did not try to return a table of instances using the `ec2` attribute. Perhaps this should not be the default?

This has been done in conjunction with modifications to the `marketplace_image` cookbook.


Signed-off-by: Russell Seymour <russell.seymour@turtlesystems.co.uk>