### PR TITLE
[CLOUD-540] Install Cloudformation tools on AWS images

### DIFF
--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_publishing_enable.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_publishing_enable.rb
@@ -42,3 +42,8 @@ service "firewalld" do
   action [:disable, :stop]
   only_if { node["platform"] == "centos" && node["platform_version"].start_with?("7.") }
 end
+
+cfn_tools "centos7" do
+  action :install
+  only_if { node["chef-marketplace"]["platform"] == "aws" }
+end

--- a/files/chef-marketplace-cookbooks/chef-marketplace/resources/cfn_tools.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/resources/cfn_tools.rb
@@ -1,0 +1,67 @@
+require 'uri'
+
+actions :install
+default_action :install
+
+property :src_url,
+  String,
+  default: 'https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz'
+
+action :install do
+  unless tools_installed?
+    converge_by 'install cloudformation tools' do
+      package 'epel-release'
+      package 'python-pip'
+
+      directory '/opt/aws/bin' do
+        recursive true
+      end
+
+      remote_file '/tmp/cfn.tar.gz' do
+        source src_url
+      end
+
+      bash 'build and install tools' do
+        cwd "/tmp"
+        code <<-EOH
+          tar xpf cfn.tar.gz
+          cd aws-cfn-bootstrap-*
+          python setup.py build
+          python setup.py install
+          ln -s /usr/init/redhat/cfn-hup /etc/init.d/cfn-hup
+          chmod 775 /usr/init/redhat/cfn-hup
+        EOH
+      end
+
+      cfn_binary_names.each do |cmd|
+        link ::File.join("/opt/aws/bin", cmd) do
+          to ::File.join("/usr/bin", cmd)
+        end
+      end
+    end
+  end
+end
+
+action_class do
+  def cfn_binary_names
+    %w(
+      cfn-hup
+      cfn-init
+      cfn-signal
+      cfn-elect-cmd-leader
+      cfn-get-metadata
+      cfn-send-cmd-event
+      cfn-send-cmd-result
+    )
+  end
+
+  def tools_installed?
+    cfn_binary_names.all? do |t|
+      begin
+        ::File.executable?(::File.join('/opt/aws/bin', t))
+      rescue
+        false
+      end
+    end
+  end
+end


### PR DESCRIPTION
As we transition our AWS offerings to use CloudFormation we'll need to
properly signal the stack when setup is completed. During publishing on
we now ensure that the tools are installed and linked.