### PR TITLE
Workaround race condition in creating an enterprise

### DIFF
--- a/files/chef-marketplace-gem/lib/marketplace/setup.rb
+++ b/files/chef-marketplace-gem/lib/marketplace/setup.rb
@@ -105,7 +105,7 @@ class Marketplace
         "--password=#{passwords['admin_user'].shellescape}",          # admin password
         "--builder-password=#{passwords['builder_user'].shellescape}" # builder password
       ].join(" ")
-      retry_command(create_ent, retries: 1)
+      retry_command(create_ent, retries: 3, seconds: 10)
     end
 
     #


### PR DESCRIPTION
There seems to be a race condition in which automate is restarting between actions and we are unable to create an enterprise. For now, we want to just retry again and add a longer delay than the default two
seconds between each retry.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>