### PR TITLE
Fix Starter Kit Download issues add improvements for debugging.

### DIFF
--- a/arm-templates/automate/automate_setup.rb
+++ b/arm-templates/automate/automate_setup.rb
@@ -32,10 +32,14 @@ open("/etc/chef-marketplace/marketplace.rb", "a") do |config|
   config.puts(%Q{api_fqdn "#{@fqdn}"})
 end
 
+environment = {
+  'HOME' => '/root'
+}
+
 # Configure the hostname
-hostname = Mixlib::ShellOut.new("chef-marketplace-ctl hostname #{@fqdn}")
+hostname = Mixlib::ShellOut.new("chef-marketplace-ctl hostname #{@fqdn}", env: environment)
 hostname.run_command
 
 # Configure Automate
-configure = Mixlib::ShellOut.new("chef-marketplace-ctl setup --preconfigure")
+configure = Mixlib::ShellOut.new("chef-marketplace-ctl setup --preconfigure", env: environment)
 configure.run_command

--- a/cloudformation/marketplace_byol.yml
+++ b/cloudformation/marketplace_byol.yml
@@ -253,6 +253,7 @@ Resources:
           - |+
 
           - - '#!/bin/bash -ex'
+            - export HOME=/root
             - !If
               - HasLicenseUrl
               - !Sub >-

--- a/files/chef-marketplace-cookbooks/chef-marketplace/attributes/default.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/attributes/default.rb
@@ -16,6 +16,7 @@ default["chef-marketplace"].tap do |m|
   m["platform"] = "aws"
   m["user"] = "ec2-user"
   m["api_ssl_port"] = 443
+  m["update_channel"] = :stable
   m["reporting"]["cron"]["enabled"] = true
   m["reporting"]["cron"]["expression"] = "0 0 * * *"
   m["reporting"]["cron"]["year"] = "date +%Y"

--- a/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_upgrade_automate.rb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/recipes/_upgrade_automate.rb
@@ -14,7 +14,7 @@ end
 # Chef Automate
 chef_ingredient 'delivery' do
   action :upgrade
-
+  channel node['chef-marketplace']['update_channel'].to_sym
   notifies :run, 'bash[delivery-ctl reconfigure]', :immediately
   notifies :run, 'bash[yum-clean-all]', :immediately
   notifies :run, 'bash[apt-get-clean]', :immediately

--- a/files/chef-marketplace-cookbooks/chef-marketplace/templates/default/biscotti_nginx_upstreams.conf.erb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/templates/default/biscotti_nginx_upstreams.conf.erb
@@ -1,3 +1,5 @@
 upstream biscotti {
-  server 127.0.0.1:<%= node['chef-marketplace']['biscotti']['port'] %>;
+  # Disable fail_timeout and max_fails accounting for Unicorn.
+  # https://git.io/vAzf0
+  server 127.0.0.1:<%= node['chef-marketplace']['biscotti']['port'] %> max_fails=0 fail_timeout=0;
 }

--- a/files/chef-marketplace-ctl-commands/setup.rb
+++ b/files/chef-marketplace-ctl-commands/setup.rb
@@ -7,6 +7,7 @@ add_command_under_category "setup", "Setup", "Set up the Chef Server Marketplace
   options.preconfigure = false
   options.license_url = nil
   options.license_base64 = nil
+  options.debug = false
 
   OptionParser.new do |opts|
     opts.banner = "Usage: chef-marketplace-ctl setup [options]"
@@ -58,6 +59,10 @@ add_command_under_category "setup", "Setup", "Set up the Chef Server Marketplace
 
     opts.on("--license-base64 ENCODED_LICENSE", "A base64 enconded Chef Automate license") do |license|
       options.license_base64 = license
+    end
+
+    opts.on("--debug", "Enable debug logging output.") do
+      options.debug = true
     end
 
     opts.on("-h", "--help", "Show this message") do

--- a/files/chef-marketplace-ctl-commands/upgrade.rb
+++ b/files/chef-marketplace-ctl-commands/upgrade.rb
@@ -1,5 +1,7 @@
 require "json"
 
+RELEASE_CHANNELS = %w(unstable current stable)
+
 add_command_under_category "upgrade", "Maintenance", "Upgrade or install Chef software", 2 do
   config = {
     "chef-marketplace" => {
@@ -62,6 +64,10 @@ add_command_under_category "upgrade", "Maintenance", "Upgrade or install Chef so
 
     opts.on("-d", "--automate", "Upgrade Chef Automate") do
       config["chef-marketplace"]["upgrade_packages"] << "automate"
+    end
+
+    opts.on("-r RELEASE_CHANNEL", "--channel RELEASE_CHANNEL", RELEASE_CHANNELS, "Release channel to use for downloading packages to install") do |channel|
+      config["chef-marketplace"]["update_channel"] = channel.to_sym
     end
 
     opts.on("-h", "--help", "Show this message") do

--- a/files/chef-marketplace-gem/lib/marketplace/setup.rb
+++ b/files/chef-marketplace-gem/lib/marketplace/setup.rb
@@ -77,24 +77,25 @@ class Marketplace
       # * determine correct email
       # * create user with existing delivery.{pem,pub}
       create_user = [
-        "chef-server-ctl user-create",
-        "delivery",                         # options.username.to_s.shellescape,
-        "Automate",                         # options.first_name.to_s.shellescape,
-        "User",                             # options.last_name.to_s.shellescape,
-        "automate@chef.io",                 # options.email.to_s.shellescape,
-        passwords["chef_user"].shellescape, # options.password.to_s.shellescape
-        "-f /etc/delivery/delivery.pem",
-      ].join(" ")
+        "chef-server-ctl",
+        "user-create",
+        "delivery",                         # options.username,
+        "Automate",                         # options.first_name,
+        "User",                             # options.last_name,
+        "automate@chef.io",                 # options.email,
+        passwords["chef_user"],             # options.password
+        "-f", "/etc/delivery/delivery.pem",
+      ].shelljoin
       retry_command(create_user, retries: 1)
 
       # create chef server org
       create_org = [
-        "chef-server-ctl org-create",
-        "delivery", # options.organization.to_s.shellescape,
-        "delivery", # options.organization.to_s.shellescape,
-        "-a",
-        "delivery"  # options.username.to_s.shellescape
-      ].join(" ")
+        "chef-server-ctl",
+        "org-create",
+        "delivery",       # options.organization,
+        "delivery",       # options.organization,
+        "-a", "delivery"  # options.username
+      ].shelljoin
       retry_command(create_org, retries: 1)
 
       # Try to wait for automate to come up before attempting to create the
@@ -104,12 +105,13 @@ class Marketplace
 
       # create automate enterprise
       create_ent = [
-        "delivery-ctl create-enterprise",
+        "delivery-ctl",
+        "create-enterprise",
         "default",                                                    # enterprise name
         "--ssh-pub-key-file=/etc/delivery/builder.pub",               # builder public key
-        "--password=#{passwords['admin_user'].shellescape}",          # admin password
-        "--builder-password=#{passwords['builder_user'].shellescape}" # builder password
-      ].join(" ")
+        "--password=#{passwords['admin_user']}",                      # admin password
+        "--builder-password=#{passwords['builder_user']}"             # builder password
+      ].shelljoin
       retry_command(create_ent, retries: 3, seconds: 10)
     end
 

--- a/files/chef-marketplace-gem/lib/marketplace/setup.rb
+++ b/files/chef-marketplace-gem/lib/marketplace/setup.rb
@@ -97,6 +97,11 @@ class Marketplace
       ].join(" ")
       retry_command(create_org, retries: 1)
 
+      # Try to wait for automate to come up before attempting to create the
+      # automate enterprise. This has the added bonus of being able to log
+      # the state of all the services while we wait.
+      retry_command("delivery-ctl status", retries: 60, seconds: 2) # Wait up to two minutes.
+
       # create automate enterprise
       create_ent = [
         "delivery-ctl create-enterprise",
@@ -367,6 +372,7 @@ class Marketplace
       retries.times do
         command = Mixlib::ShellOut.new(cmd)
         command.environment = env unless env.empty?
+        command.live_stream = STDOUT if options.debug
         command.run_command
         return unless command.error?
         ui.say("#{cmd} failed, retrying...")


### PR DESCRIPTION
The main fix is to set the HOME environment variable in the cloudformation and ARM templates. 

This PR also implements a `--debug` log output for `chef-marketplace-ctl` and a `--channel` option to allow the user to specify the release channel to use for installing Chef Automate.

Fixes SUSTAIN-844

See the commit messages for complete details.

/cc @btm 