### PR TITLE
Increase timeout during preconfigure in Azure.

### DIFF
--- a/arm-templates/automate/automate_setup.rb
+++ b/arm-templates/automate/automate_setup.rb
@@ -37,9 +37,12 @@ environment = {
 }
 
 # Configure the hostname
-hostname = Mixlib::ShellOut.new("chef-marketplace-ctl hostname #{@fqdn}", env: environment)
+hostname = Mixlib::ShellOut.new("chef-marketplace-ctl hostname #{@fqdn}")
+hostname.environment = environment
 hostname.run_command
 
 # Configure Automate
-configure = Mixlib::ShellOut.new("chef-marketplace-ctl setup --preconfigure", env: environment)
+configure = Mixlib::ShellOut.new("chef-marketplace-ctl setup --preconfigure")
+configure.environment = environment
+configure.timeout = 1200
 configure.run_command


### PR DESCRIPTION
The chef-marketplace-ctl command was failing with a timeout during the preconfigure step as it was taking longer than the mixlib-shellout default 600 seconds to complete.