### PR TITLE
Bug Fixes for Azure and AWS Metered

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -5,13 +5,13 @@ require('load-grunt-tasks')(grunt);
 var branch=process.env.sourcebranch;
 var folder=grunt.option('folder')||branch||'.';
 var solutionjsonfiles = [`${folder}/**/*.json`,`!${folder}/node_modules/**/*.json`];
-var createUIDefinition=`${folder}/createUIDefinition.json`;
+var createUiDefinition=`${folder}/createUiDefinition.json`;
 
 grunt.initConfig({
     fileExists: {
             scripts: [`${folder}/mainTemplate.json`]
     },
-    uidef: grunt.file.readJSON(createUIDefinition),
+    uidef: grunt.file.readJSON(createUiDefinition),
     jsonlint: {
         all: {
             src: solutionjsonfiles
@@ -24,7 +24,7 @@ grunt.initConfig({
             banUnknownProperties: true
         },
         myTarget: {
-            src: [createUIDefinition]
+            src: [createUiDefinition]
         }
     }
 });

--- a/files/chef-marketplace-cookbooks/chef-marketplace/templates/default/chef-marketplace-cloud-init-setup.erb
+++ b/files/chef-marketplace-cookbooks/chef-marketplace/templates/default/chef-marketplace-cloud-init-setup.erb
@@ -1,6 +1,8 @@
 #!/bin/bash
+export HOME="/root"
+
 mkdir -p /var/opt/chef-marketplace/
 touch /var/opt/chef-marketplace/cloud_init_running
-chef-marketplace-ctl setup --preconfigure
-touch /var/opt/chef-marketplace/preconfigured
+chef-marketplace-ctl setup --preconfigure && touch /var/opt/chef-marketplace/preconfigured
+
 rm -rf /var/opt/chef-marketplace/cloud_init_running


### PR DESCRIPTION
This includes two fixes.

- The `arm-publish` command expected a different filename than what we set in the Makefile and committed. This updates the filename and Makefile to match to the rest of the parts.
- Set HOME for cloud-init scripts with Metered AWS offering.