### PR TITLE
[ci] Add artifactory to omnibus/Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 # Install omnibus software
 gem "omnibus-software", github: "opscode/omnibus-software"
 gem "omnibus", github: "opscode/omnibus"
+gem "artifactory"
 gem "omnibus-ctl", github: "chef/omnibus-ctl"
 gem "chef"
 gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    artifactory (3.0.5)
     ast (2.4.0)
     awesome_print (1.8.0)
     aws-sdk (2.11.22)
@@ -358,6 +359,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  artifactory
   aws-sdk (~> 2)
   berkshelf
   chef
@@ -375,4 +377,4 @@ DEPENDENCIES
   test-kitchen
 
 BUNDLED WITH
-   1.15.4
+   1.17.3


### PR DESCRIPTION
### Description

This change only affects CI. The artifactory gem is required for the publish part of the build stage.

### Related Issue

https://github.com/chef/omnibus-buildkite-plugin/issues/22