### PR TITLE
Updating Expeditor configuration

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -30,11 +30,11 @@ subscriptions:
     actions:
       - built_in:promote_artifactory_artifact
 
-artifact_actions:
-  promoted_to_stable:
-    - built_in:rollover_changelog
-    - built_in:create_github_release
-    - built_in:notify_chefio_slack_channels
+  - workload: artifact_published:stable:marketplace:*
+    actions:
+      - built_in:rollover_changelog
+      - built_in:create_github_release
+      - built_in:notify_chefio_slack_channels
 
 artifact_channels:
   - unstable

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -9,20 +9,26 @@ pipelines:
       env:
         - ADHOC: true
 
-merge_actions:
-  - built_in:bump_version:
-      ignore_labels:
-        - "Version: Skip Bump"
-        - "Expeditor: Skip All"
-  - built_in:update_changelog:
-      ignore_labels:
-        - "Changelog: Skip Update"
-        - "Expeditor: Skip All"
-  - trigger_pipeline:omnibus/release:
-      ignore_labels:
-        - "Omnibus: Skip Build"
-        - "Expeditor: Skip All"
-      only_if: built_in:bump_version
+subscriptions:
+  - workload: pull_request_merged:{{github_repo}}:{{release_branch}}:*
+    actions:
+      - built_in:bump_version:
+          ignore_labels:
+            - "Version: Skip Bump"
+            - "Expeditor: Skip All"
+      - built_in:update_changelog:
+          ignore_labels:
+            - "Changelog: Skip Update"
+            - "Expeditor: Skip All"
+      - trigger_pipeline:omnibus/release:
+          ignore_labels:
+            - "Omnibus: Skip Build"
+            - "Expeditor: Skip All"
+          only_if: built_in:bump_version
+  
+  - workload: project_promoted:{{agent_id}}:*
+    actions:
+      - built_in:promote_artifactory_artifact
 
 artifact_actions:
   promoted_to_stable:
@@ -30,10 +36,7 @@ artifact_actions:
     - built_in:create_github_release
     - built_in:notify_chefio_slack_channels
 
-promote:
-  actions:
-    - built_in:promote_artifactory_artifact
-  channels:
-    - unstable
-    - current
-    - stable
+artifact_channels:
+  - unstable
+  - current
+  - stable


### PR DESCRIPTION
Signed-off-by: Swati Keshari <skeshari@msystechnologies.com>

1. The merge_actions subscription shortcut has been deprecated. All subscriptions should be declared via the subscriptions block for clarity.
 2. The promote block has been deprecated. All actions should be declared via the subscriptions block for clarity.
3. The promote configuration block has been deprecated for clarity. Artifact channels are relevant to things beyond promotions.